### PR TITLE
Haml 6 Support

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 2.0.0"
   s.required_ruby_version     = ">= 2.3.0"
 
-  s.add_dependency "haml",          [">= 4.0.6", "< 6.0"]
+  s.add_dependency "haml",          [">= 4.0.6"]
   s.add_dependency "activesupport", [">= 5.1"]
   s.add_dependency "actionpack",    [">= 5.1"]
   s.add_dependency "railties",      [">= 5.1"]


### PR DESCRIPTION
Haml 6 is out https://github.com/haml/haml/releases/tag/v6.0.0 this PR changes the dependency to support newer release